### PR TITLE
Add opacity-hidden class to Social component

### DIFF
--- a/src/components/Social.astro
+++ b/src/components/Social.astro
@@ -10,7 +10,7 @@ interface Props {
 const {href, color, tooltip} = Astro.props
 ---
 
-<Tooltip class="Social transition-all" text={tooltip}>
+<Tooltip class="Social transition-all opacity-0" text={tooltip}>
     <a
         class="bg-white rounded-[35%] aspect-square flex items-center justify-center shadow"
         style={{color}}


### PR DESCRIPTION
## Summary

This PR adds `opacity-0` class to the Social component, making it initially hidden. This change suggests the component will be revealed through animation or interaction, likely using the newly added Tailwind CSS animation utilities.

The modification:
- Adds `opacity-0` to the Tooltip component class
- Maintains existing transition and styling
- Enables fade-in animations through CSS or JavaScript