### PR TITLE
Add staggered zoom-in animation for social icons

### DIFF
--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -51,4 +51,14 @@ const socialsWithIcons = socials.map((social) => ({
         .querySelectorAll("svg title")) {
         title.remove()
     }
+    for (const social_ of document.querySelectorAll(".Social")) {
+        const social = social_ as HTMLElement
+        setTimeout(() => {
+            social.classList.remove("opacity-0")
+            social.classList.add("zoom-in-bounce")
+            social.addEventListener("animationend", () => {
+                social.classList.remove("zoom-in-bounce")
+            })
+        }, Math.random() * 500)
+    }
 </script>


### PR DESCRIPTION
## Summary

This PR adds an animated reveal effect for social media icons with staggered timing:

**Features:**
- Finds all elements with `.Social` class
- Removes `opacity-0` and adds `zoom-in-bounce` animation with random delays (0-500ms)
- Creates a cascading reveal effect for multiple social icons
- Cleans up animation classes after completion to prevent re-triggering

**Animation Flow:**
1. Initially hidden with `opacity-0` (from previous commit)
2. Each icon gets a random delay up to 500ms
3. Zoom-in-bounce animation plays
4. Animation class is removed after completion

This creates an engaging, staggered entrance animation for the social links.