### PR TITLE
Refine tooltip styling and padding

### DIFF
--- a/src/components/Tooltip.astro
+++ b/src/components/Tooltip.astro
@@ -10,7 +10,7 @@ const {class: className, text} = Astro.props
 <div class:list={["relative group inline-block", className]}>
     <slot />
     <div
-        class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-yellow-100 text-neutral-800 text-xs rounded-md whitespace-nowrap opacity-0 scale-0 translate-y-2 group-hover:opacity-100 group-hover:scale-100 group-hover:translate-y-0 transition-all duration-300 ease-out pointer-events-none"
+        class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-1 py-0.5 bg-yellow-100 text-neutral-800 text-xs rounded-md whitespace-nowrap opacity-0 scale-0 translate-y-2 group-hover:opacity-100 group-hover:scale-100 group-hover:translate-y-0 transition-all duration-300 ease-out pointer-events-none font-medium"
     >
         {text}
         <div


### PR DESCRIPTION
## Summary

This PR makes subtle improvements to the Tooltip component styling:

**Changes:**
- Reduced horizontal padding from `px-2` to `px-1` for tighter spacing
- Reduced vertical padding from `py-1` to `py-0.5` for more compact appearance
- Added `font-medium` class for better text readability

These adjustments create a more refined and compact tooltip appearance while maintaining the smooth hover animations and positioning behavior.