### PR TITLE
Reorganize projects into foss and side categories

### DIFF
--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,48 +1,58 @@
-[
-    {
-        "name": "goboscript",
-        "description": "Programming language with web-based IDE that compiles to children's block-based programming language Scratch.",
-        "repo": "https://github.com/aspizu/goboscript",
-        "deployment": "https://aspizu.github.io/goboscript.ide/",
-        "docs": "https://aspizu.github.io/goboscript/"
-    },
-    {
-        "name": "Nixite",
-        "description": "Generates bash scripts to unattendedly install selected Linux software. Automatically configures system, suppresses confirmation prompts and uses the best available installation method.",
-        "repo": "https://github.com/aspizu/nixite",
-        "deployment": "https://aspizu.github.io/nixite"
-    },
-    {
-        "name": "tshu",
-        "description": "Python library for safe, cross-platform shell execution. Uses t-strings and a Rust-backed bash implementation.",
-        "repo": "https://github.com/aspizu/tshu",
-        "docs": "https://aspizu.github.io/tshu"
-    },
-    {
-        "name": "PIXELATEDKISSES",
-        "description": "Camera app that applies a duotone filter inspired by the album artwork of Joji.",
-        "repo": "https://github.com/aspizu/PIXELATEDKISSES",
-        "deployment": "https://aspiz.uk/PIXELATEDKISSES"
-    },
-    {
-        "name": "instax",
-        "description": "Generates printable PDFs for DIY instant camera photographs.",
-        "repo": "https://github.com/aspizu/instax",
-        "deployment": "https://aspizu.github.io/instax"
-    },
-    {
-        "name": "musync",
-        "description": "Sync lossless music collection to MP3 efficiently. Useful for old car stereos that only support MP3.",
-        "repo": "https://github.com/aspizu/musync"
-    },
-    {
-        "name": "msglint",
-        "description": "Opinionated commit messages linter. Enforces conventional commits, imperative mood, discourages laziness.",
-        "repo": "https://github.com/aspizu/msglint"
-    },
-    {
-        "name": "neocities-sync",
-        "description": "Deploys projects to Neocities using diffed updates. Suitable for Vite, Astro, and Next.js builds.",
-        "repo": "https://github.com/aspizu/neocities-sync"
-    }
-]
+{
+    "foss": [
+        {
+            "name": "goboscript",
+            "description": "Programming language with web-based IDE that compiles to children's block-based programming language Scratch.",
+            "repo": "https://github.com/aspizu/goboscript",
+            "deployment": "https://aspizu.github.io/goboscript.ide/",
+            "docs": "https://aspizu.github.io/goboscript/"
+        },
+        {
+            "name": "Nixite",
+            "description": "Generates bash scripts to unattendedly install selected Linux software. Automatically configures system, suppresses confirmation prompts and uses the best available installation method.",
+            "repo": "https://github.com/aspizu/nixite",
+            "deployment": "https://aspizu.github.io/nixite"
+        },
+        {
+            "name": "tshu",
+            "description": "Python library for safe, cross-platform shell execution. Uses t-strings and a Rust-backed bash implementation.",
+            "repo": "https://github.com/aspizu/tshu",
+            "docs": "https://aspizu.github.io/tshu"
+        }
+    ],
+    "side": [
+        {
+            "name": "PIXELATEDKISSES",
+            "description": "Camera app that applies a duotone filter inspired by the album artwork of Joji.",
+            "repo": "https://github.com/aspizu/PIXELATEDKISSES",
+            "deployment": "https://aspiz.uk/PIXELATEDKISSES"
+        },
+        {
+            "name": "bunnie",
+            "description": "bunnie lets u use Bun as the templating language in ur Rust applications.",
+            "repo": "https://github.com/aspizu/bunnie"
+        },
+        {
+            "name": "musync",
+            "description": "Sync lossless music collection to MP3 efficiently. Useful for old car stereos that only support MP3.",
+            "repo": "https://github.com/aspizu/musync"
+        },
+
+        {
+            "name": "neocities-sync",
+            "description": "Deploys projects to Neocities using diffed updates. Suitable for Vite, Astro, and Next.js builds.",
+            "repo": "https://github.com/aspizu/neocities-sync"
+        },
+        {
+            "name": "msglint",
+            "description": "Opinionated commit messages linter. Enforces conventional commits, imperative mood, discourages laziness.",
+            "repo": "https://github.com/aspizu/msglint"
+        },
+        {
+            "name": "instax",
+            "description": "Generates printable PDFs for DIY instant camera photographs.",
+            "repo": "https://github.com/aspizu/instax",
+            "deployment": "https://aspizu.github.io/instax"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

This PR restructures the projects.json file to categorize projects by type:

**New Structure:**
- `foss`: Free and open source software projects (goboscript, Nixite, tshu)
- `side`: Side projects and tools (PIXELATEDKISSES, bunnie, musync, neocities-sync, msglint, instax)

**Benefits:**
- Better organization by project purpose
- Easier to display different categories separately
- More scalable structure for future projects
- Clear distinction between main FOSS projects and experimental tools

The project data itself remains unchanged, only the organizational structure is modified to support categorization in the portfolio display.